### PR TITLE
fix: avoid pillar::type_sum() promise error in print.qlm_coded

### DIFF
--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -352,7 +352,15 @@ print.qlm_coded <- function(x, ...) {
 
   cat("\n")
 
-  # Print data using parent class method
-  NextMethod()
+  # Print data as tibble. Strip qlm_coded class first to avoid a
+  # "promise already under evaluation" error in pillar::type_sum() that
+  # can occur when NextMethod() passes the same promise through multiple
+  # S3 dispatch hops (print.qlm_coded -> print.tbl_df -> print.tbl ->
+  # format_tbl -> force(x)).
+  x_tbl <- x
+  class(x_tbl) <- setdiff(class(x_tbl), "qlm_coded")
+  print(x_tbl, ...)
+
+  invisible(x)
 }
 


### PR DESCRIPTION
When using local models from ollama he function qlm_code would return the following error:
Error in `pillar::type_sum()`:
! promise already under evaluation: recursive default argument reference or earlier problems?

Replace NextMethod() with explicit class-stripping before delegating to tibble's print method. When NextMethod() passes the same promise through the dispatch chain (print.qlm_coded -> print.tbl_df -> print.tbl -> format_tbl -> force(x)), pillar::type_sum() can throw "promise already under evaluation" in certain conditions, such as when ellmer adds a .error list column with Turn S7 objects for failed parallel_chat_structured() turns.

Also, add invisible(x) to properly return the original qlm_coded object.

Now, using the local models that do not have thinking capabilities (i.e., ministral-3:3b or llama3.1:8b) works correctly; however, when trying to use nwr models with thinking capabilities (i.e., qwen3.5:0.8b) or cloud models (i.e., qwen3.5:cloud or kimi-k2:1t-cloud) it retrun errors like this:

Failed to extract data from 1/1 turns
* 1: lexical error: invalid char in json text.  The overall tone is resolute-ye (right here) ------^
