### PR TITLE
Integrating workshop site for info/registration

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -12,6 +12,7 @@ navbar:
     - quick-start
     - tutorials
     - examples
+    - workshops
     - reference
     - news
     right:
@@ -52,6 +53,9 @@ navbar:
     reference:
       text: Reference
       href: reference/index.html
+    workshops:
+      text: Workshops
+      href: articles/pkgdown/workshops.html
     github:
       icon: fab fa-github
       href: https://github.com/quallmer/quallmer

--- a/vignettes/pkgdown/workshops.Rmd
+++ b/vignettes/pkgdown/workshops.Rmd
@@ -1,0 +1,55 @@
+---
+title: "Workshops"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Workshops}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+Learn how to use quallmer for your research in one of our workshops - in person or online. 
+
+***
+
+## EPSS 2026 Belfast, pre-conference workshop (in person)
+
+### Qualitative analysis with LLMs: The quallmer toolbox
+
+| | |
+|:--|:--|
+| **When** | Wednesday, June 17, 2026, 9:00am–12:30pm |
+| **Where** | ICC Belfast, UK ([EPSS 2026 Conference](https://epssnet.org/belfast-2026/)) |
+| **Format** | Half-day hands-on workshop (3.5 hours) |
+| **Registration** | Free for conference attendees — [sign up here](https://forms.gle/gJeXpsiPzJmJ8bFLA) |
+
+This workshop introduces the **quallmer** R package for qualitative coding with LLMs. Learn to build custom codebooks, validate results against gold standards, and create audit trails for transparent, reproducible research.
+
+**No prior R experience required.** Bring a laptop with R and RStudio installed.
+
+**Instructors:** [Ken Benoit](https://kenbenoit.net/) & [Seraphine F. Maerz](https://seraphinem.github.io/)
+
+***
+
+## Instats online workshops
+
+Online workshops via [Instats](https://instats.org/expert/seraphine-maerz-2?view=Seminars), live-streamed and interactive with Q&A and ongoing support via the instats forum.
+
+| Workshop | Date | |
+|:--|:--|:--|
+| AI-Powered Qualitative Analysis in R (Americas) | May 14, 2026 | [Register](https://instats.org/seminar/ai-powered-qualitative-analysis-in-r-ame) |
+| AI-Powered Qualitative Analysis in R (Europe) | June 16, 2026 | [Register](https://instats.org/seminar/ai-powered-qualitative-analysis-in-r-eur) |
+
+
+
+***
+<!--
+## Workshop materials
+
+### 2026
+
+**31 Mar — Seraphine F. Maerz**
+Analysing Qualitative Data with LLMs
+
+[View slides](https://quantilab.github.io/sharezone/quallmer_slides.html) |
+[Tutorial](https://quantilab.github.io/sharezone/quallmer_tutorial.html)
+-->


### PR DESCRIPTION
Summary

- addresses #103 

  Adds a Workshops page to the pkgdown site with:
  - EPSS 2026 Belfast pre-conference workshop announcement (June 17, 2026)
  - INSTATS workshops info
  - Workshop materials section (this is where we can upload material for participants)
  

  Changes

  - _pkgdown.yml: Add "Workshops" navbar link between Examples and Reference
  - vignettes/pkgdown/workshops.Rmd: New workshops page with registration info and materials

  ---
