### PR TITLE
Readme segment

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -63,7 +63,7 @@ Using `qlm_code()`, users can apply codebook-based qualitative coding powered by
 
 #### `qlm_compare()`
 - Compares multiple `qlm_coded` objects to assess inter-rater reliability.
-- Computes agreement metrics including Krippendorff's alpha, Cohen's kappa, and Fleiss' kappa.
+- Computes agreement metrics including Krippendorff's alpha, Cohen's kappa, and Fleiss' kappa.  When comparing documents that have been segmented, automatically computes all four variants of Krippendorff's alpha for unitizing (2019, section 12.6) -- the only R package to do so.
 - Useful for evaluating consistency across different coders, models, or coding runs.
 
 #### `qlm_validate()`
@@ -110,3 +110,7 @@ To learn more about how to use the package, please refer to our [step-by-step tu
 ## Acknowledgments
 
 Development of this package was assisted by [Claude Code](https://claude.com/claude-code), an AI coding assistant by Anthropic, for code refactoring, documentation updates, and package restructuring.
+
+## References
+
+Krippendorff, K. (2019). _Content Analysis: An Introduction to Its Methodology_ (4th ed.). Sage. doi:10.4135/9781071878781

--- a/README.Rmd
+++ b/README.Rmd
@@ -32,7 +32,7 @@ Using `qlm_code()`, users can apply codebook-based qualitative coding powered by
 
 # The quallmer workflow
 
-## 1. Define codebook and prepare data
+## 1. Define codebook 
 
 #### `qlm_codebook()`
 - Creates custom codebooks tailored to specific research questions and data types.
@@ -40,16 +40,17 @@ Using `qlm_code()`, users can apply codebook-based qualitative coding powered by
 - Example codebook objects (e.g., `data_codebook_sentiment`) demonstrate how to use built-in codebooks for common qualitative coding tasks.
 - Extensible framework allows researchers to define domain-specific coding schemes.
 
-#### `qlm_segment()`
-- Segments texts into thematic or conceptual units using an LLM.
-- Useful for aspect-based analysis, quasi-sentence segmentation, or splitting texts by topic before coding.
-
 ## 2. Code data
 
 #### `qlm_code()`
 - Applies LLM-based coding to qualitative data using a `qlm_codebook`.
 - Works with any LLM supported by [ellmer](https://ellmer.tidyverse.org/index.html).
 - Returns a `qlm_coded` object containing the coded results and metadata for reproducibility.
+
+#### `qlm_segment()` (optional)
+- Segments texts into thematic or conceptual units using an LLM.
+- Useful for aspect-based analysis, quasi-sentence segmentation, or splitting texts by topic.
+- Returns a corpus of segmented units that can be coded with `qlm_code()` for more granular analysis (in the same pass or as a separate step).
 
 ## 3. Replicate with different settings
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ learning.**
 
 # The quallmer workflow
 
-## 1. Define codebook and prepare data
+## 1. Define codebook
 
 #### `qlm_codebook()`
 
@@ -54,12 +54,6 @@ learning.**
 - Extensible framework allows researchers to define domain-specific
   coding schemes.
 
-#### `qlm_segment()`
-
-- Segments texts into thematic or conceptual units using an LLM.
-- Useful for aspect-based analysis, quasi-sentence segmentation, or
-  splitting texts by topic before coding.
-
 ## 2. Code data
 
 #### `qlm_code()`
@@ -69,6 +63,15 @@ learning.**
   [ellmer](https://ellmer.tidyverse.org/index.html).
 - Returns a `qlm_coded` object containing the coded results and metadata
   for reproducibility.
+
+#### `qlm_segment()` (optional)
+
+- Segments texts into thematic or conceptual units using an LLM.
+- Useful for aspect-based analysis, quasi-sentence segmentation, or
+  splitting texts by topic.
+- Returns a corpus of segmented units that can be coded with
+  `qlm_code()` for more granular analysis (in the same pass or as a
+  separate step).
 
 ## 3. Replicate with different settings
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,10 @@ learning.**
 - Compares multiple `qlm_coded` objects to assess inter-rater
   reliability.
 - Computes agreement metrics including Krippendorff’s alpha, Cohen’s
-  kappa, and Fleiss’ kappa.
+  kappa, and Fleiss’ kappa. When comparing documents that have been
+  segmented, automatically computes all four variants of Krippendorff’s
+  alpha for unitizing (2019, section 12.6) – the only R package to do
+  so.
 - Useful for evaluating consistency across different coders, models, or
   coding runs.
 
@@ -159,3 +162,8 @@ Development of this package was assisted by [Claude
 Code](https://claude.com/claude-code), an AI coding assistant by
 Anthropic, for code refactoring, documentation updates, and package
 restructuring.
+
+## References
+
+Krippendorff, K. (2019). *Content Analysis: An Introduction to Its
+Methodology* (4th ed.). Sage. <doi:10.4135/9781071878781>


### PR DESCRIPTION
# Summary

- Addresses #105 

  Documents qlm_segment() in the README and workflow tutorial.

  Changes

  - README.Rmd: Added qlm_segment() to the codebook section for segmenting texts into thematic units before coding
  - workflow.Rmd: Added tip box mentioning qlm_segment() for splitting texts into quasi-sentences, aspects, or topics
