### PR TITLE
Fix ellmer dots

### DIFF
--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -23,11 +23,11 @@
 #'   cost-effective for large jobs but may have longer turnaround times.
 #'   Default is `FALSE`. See [ellmer::batch_chat_structured()] for details.
 #' @param ... Additional arguments passed to [ellmer::chat()],
-#'   [ellmer::parallel_chat_structured()], or [ellmer::batch_chat_structured()],
-#'   based on argument name. Arguments recognized by
-#'   [ellmer::parallel_chat_structured()] take priority when there are overlaps.
-#'   Batch-specific arguments (`path`, `wait`, `ignore_hash`) are only used when
-#'   `batch = TRUE`. Arguments not recognized by any function will generate a warning.
+#'   [ellmer::parallel_chat_structured()], or [ellmer::batch_chat_structured()].
+#'   Arguments recognized by [ellmer::parallel_chat_structured()] or
+#'   [ellmer::batch_chat_structured()] are routed there; all other arguments
+#'   (including provider-specific arguments like `base_url`, `credentials`, or
+#'   `api_args` for OpenAI-compatible endpoints) are passed to [ellmer::chat()].
 #' @param name Character string identifying this coding run. Default is `NULL`.
 #' @param notes Optional character string with descriptive notes about this
 #'   coding run. Useful for documenting the purpose or rationale when viewing
@@ -104,25 +104,20 @@ qlm_code <- function(x, codebook, model, ..., batch = FALSE, name = NULL, notes 
                          "seed", "response_format")
 
   # Route ... arguments
-  # All non-chat arguments go to execution_args (for either parallel or batch execution)
+  # execution_args go to parallel_chat_structured or batch_chat_structured
+  # Everything else (including provider-specific args like base_url) goes to chat()
   dots <- list(...)
   dot_names <- names(dots)
 
-  chat_args <- dots[dot_names %in% chat_arg_names]
-
-  # execution_args contains everything that's for parallel_chat_structured or batch_chat_structured
+  # execution_args contains arguments for parallel_chat_structured or batch_chat_structured
   execution_arg_names <- unique(c(pcs_arg_names, batch_arg_names))
   execution_args <- dots[dot_names %in% execution_arg_names]
 
-  # Warn about unrecognized arguments
-  all_valid_names <- unique(c(chat_arg_names, execution_arg_names))
-  unknown_names <- setdiff(dot_names, all_valid_names)
-  if (length(unknown_names) > 0) {
-    cli::cli_warn(c(
-      "The following {cli::qty(length(unknown_names))} argument{?s} {?was/were} not recognized and {?has/have} been ignored:",
-      "x" = "{.arg {unknown_names}}"
-    ))
-  }
+  # chat_args gets everything NOT destined for execution functions
+
+  # This allows provider-specific args (base_url, credentials, api_args, etc.)
+  # to pass through to ellmer::chat() which forwards them to the provider
+  chat_args <- dots[!dot_names %in% execution_arg_names]
 
   # Build system prompt from role and instructions
   system_prompt <- if (!is.null(codebook$role)) {

--- a/R/qlm_segment.R
+++ b/R/qlm_segment.R
@@ -18,8 +18,10 @@
 #'   corpus. Do not include a field named `text`; it is reserved for the
 #'   verbatim segment text and is added automatically.
 #' @param ... Additional arguments passed to [ellmer::chat()] or
-#'   [ellmer::parallel_chat_structured()], based on argument name. Arguments
-#'   not recognized by either function will generate a warning.
+#'   [ellmer::parallel_chat_structured()]. Arguments recognized by
+#'   [ellmer::parallel_chat_structured()] are routed there; all other arguments
+#'   (including provider-specific arguments like `base_url`, `credentials`, or
+#'   `api_args` for OpenAI-compatible endpoints) are passed to [ellmer::chat()].
 #' @param notes Optional character string with descriptive notes about this
 #'   segmentation run. Default is `NULL`.
 #'
@@ -157,20 +159,16 @@ qlm_segment <- function(x, codebook, model, ..., name = NULL, notes = NULL) {
   }
 
   # Route ... arguments to chat() or parallel_chat_structured()
-  chat_arg_names <- names(formals(ellmer::chat))
+  # execution_args go to parallel_chat_structured
+  # Everything else (including provider-specific args like base_url) goes to chat()
   pcs_arg_names  <- names(formals(ellmer::parallel_chat_structured))
   dots       <- list(...)
   dot_names  <- names(dots)
-  chat_args      <- dots[dot_names %in% chat_arg_names]
   execution_args <- dots[dot_names %in% pcs_arg_names]
-
-  unknown_names <- setdiff(dot_names, unique(c(chat_arg_names, pcs_arg_names)))
-  if (length(unknown_names) > 0) {
-    cli::cli_warn(c(
-      "The following {cli::qty(length(unknown_names))} argument{?s} {?was/were} not recognized:",
-      "x" = "{.arg {unknown_names}}"
-    ))
-  }
+  # chat_args gets everything NOT destined for execution functions
+  # This allows provider-specific args (base_url, credentials, api_args, etc.)
+  # to pass through to ellmer::chat() which forwards them to the provider
+  chat_args      <- dots[!dot_names %in% pcs_arg_names]
 
   # Build chat object
   chat <- do.call(ellmer::chat, c(

--- a/README.Rmd
+++ b/README.Rmd
@@ -32,13 +32,17 @@ Using `qlm_code()`, users can apply codebook-based qualitative coding powered by
 
 # The quallmer workflow
 
-## 1. Define codebook 
+## 1. Define codebook and prepare data
 
 #### `qlm_codebook()`
 - Creates custom codebooks tailored to specific research questions and data types.
 - Uses `instructions` and type specifications from [ellmer](https://ellmer.tidyverse.org/reference/type_boolean.html) to define coding instructions and output structure.
 - Example codebook objects (e.g., `data_codebook_sentiment`) demonstrate how to use built-in codebooks for common qualitative coding tasks.
 - Extensible framework allows researchers to define domain-specific coding schemes.
+
+#### `qlm_segment()`
+- Segments texts into thematic or conceptual units using an LLM.
+- Useful for aspect-based analysis, quasi-sentence segmentation, or splitting texts by topic before coding.
 
 ## 2. Code data
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ learning.**
 
 # The quallmer workflow
 
-## 1. Define codebook
+## 1. Define codebook and prepare data
 
 #### `qlm_codebook()`
 
@@ -53,6 +53,12 @@ learning.**
   how to use built-in codebooks for common qualitative coding tasks.
 - Extensible framework allows researchers to define domain-specific
   coding schemes.
+
+#### `qlm_segment()`
+
+- Segments texts into thematic or conceptual units using an LLM.
+- Useful for aspect-based analysis, quasi-sentence segmentation, or
+  splitting texts by topic before coding.
 
 ## 2. Code data
 

--- a/man/annotate.Rd
+++ b/man/annotate.Rd
@@ -10,11 +10,11 @@ annotate(.data, task, model_name, ...)
 \item{task}{A task object created with \code{\link[=task]{task()}} or \code{\link[=qlm_codebook]{qlm_codebook()}}.}
 
 \item{...}{Additional arguments passed to \code{\link[ellmer:chat-any]{ellmer::chat()}},
-\code{\link[ellmer:parallel_chat]{ellmer::parallel_chat_structured()}}, or \code{\link[ellmer:batch_chat]{ellmer::batch_chat_structured()}},
-based on argument name. Arguments recognized by
-\code{\link[ellmer:parallel_chat]{ellmer::parallel_chat_structured()}} take priority when there are overlaps.
-Batch-specific arguments (\code{path}, \code{wait}, \code{ignore_hash}) are only used when
-\code{batch = TRUE}. Arguments not recognized by any function will generate a warning.}
+\code{\link[ellmer:parallel_chat]{ellmer::parallel_chat_structured()}}, or \code{\link[ellmer:batch_chat]{ellmer::batch_chat_structured()}}.
+Arguments recognized by \code{\link[ellmer:parallel_chat]{ellmer::parallel_chat_structured()}} or
+\code{\link[ellmer:batch_chat]{ellmer::batch_chat_structured()}} are routed there; all other arguments
+(including provider-specific arguments like \code{base_url}, \code{credentials}, or
+\code{api_args} for OpenAI-compatible endpoints) are passed to \code{\link[ellmer:chat-any]{ellmer::chat()}}.}
 }
 \value{
 A data frame with one row per input element, containing:

--- a/man/qlm_code.Rd
+++ b/man/qlm_code.Rd
@@ -21,11 +21,11 @@ Examples: \code{"openai/gpt-4o-mini"}, \code{"anthropic/claude-3-5-sonnet-202410
 \code{"ollama/llama3.2"}, \code{"openai"} (uses default OpenAI model).}
 
 \item{...}{Additional arguments passed to \code{\link[ellmer:chat-any]{ellmer::chat()}},
-\code{\link[ellmer:parallel_chat]{ellmer::parallel_chat_structured()}}, or \code{\link[ellmer:batch_chat]{ellmer::batch_chat_structured()}},
-based on argument name. Arguments recognized by
-\code{\link[ellmer:parallel_chat]{ellmer::parallel_chat_structured()}} take priority when there are overlaps.
-Batch-specific arguments (\code{path}, \code{wait}, \code{ignore_hash}) are only used when
-\code{batch = TRUE}. Arguments not recognized by any function will generate a warning.}
+\code{\link[ellmer:parallel_chat]{ellmer::parallel_chat_structured()}}, or \code{\link[ellmer:batch_chat]{ellmer::batch_chat_structured()}}.
+Arguments recognized by \code{\link[ellmer:parallel_chat]{ellmer::parallel_chat_structured()}} or
+\code{\link[ellmer:batch_chat]{ellmer::batch_chat_structured()}} are routed there; all other arguments
+(including provider-specific arguments like \code{base_url}, \code{credentials}, or
+\code{api_args} for OpenAI-compatible endpoints) are passed to \code{\link[ellmer:chat-any]{ellmer::chat()}}.}
 
 \item{batch}{Logical. If \code{TRUE}, uses \code{\link[ellmer:batch_chat]{ellmer::batch_chat_structured()}}
 instead of \code{\link[ellmer:parallel_chat]{ellmer::parallel_chat_structured()}}. Batch processing is more

--- a/man/qlm_segment.Rd
+++ b/man/qlm_segment.Rd
@@ -23,8 +23,10 @@ Examples: \code{"openai/gpt-4o-mini"}, \code{"anthropic/claude-3-5-sonnet-202410
 \code{"ollama/llama3.2"}, \code{"openai"} (uses default OpenAI model).}
 
 \item{...}{Additional arguments passed to \code{\link[ellmer:chat-any]{ellmer::chat()}} or
-\code{\link[ellmer:parallel_chat]{ellmer::parallel_chat_structured()}}, based on argument name. Arguments
-not recognized by either function will generate a warning.}
+\code{\link[ellmer:parallel_chat]{ellmer::parallel_chat_structured()}}. Arguments recognized by
+\code{\link[ellmer:parallel_chat]{ellmer::parallel_chat_structured()}} are routed there; all other arguments
+(including provider-specific arguments like \code{base_url}, \code{credentials}, or
+\code{api_args} for OpenAI-compatible endpoints) are passed to \code{\link[ellmer:chat-any]{ellmer::chat()}}.}
 
 \item{name}{Character string identifying this coding run. Default is \code{NULL}.}
 

--- a/tests/testthat/test-qlm_code.R
+++ b/tests/testthat/test-qlm_code.R
@@ -270,33 +270,31 @@ test_that("new_qlm_coded maintains backward compatibility with pcs_args", {
 })
 
 
-test_that("qlm_code warns about unrecognized arguments", {
+test_that("qlm_code passes provider-specific arguments to ellmer::chat", {
+
   skip_if_not_installed("ellmer")
 
   type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
   codebook <- qlm_codebook("Test", "Test prompt", type_obj)
 
-  # Mock the chat and execution functions to avoid actual API calls
-  mock_chat <- structure(list(), class = "ellmer_chat")
+  # Track what arguments are passed to ellmer::chat
+  chat_args_received <- NULL
+  mock_chat <- function(...) {
+    chat_args_received <<- list(...)
+    structure(list(), class = "ellmer_chat")
+  }
   mock_results <- data.frame(id = 1:2, score = c(0.5, 0.8))
 
   mockery::stub(qlm_code, "ellmer::chat", mock_chat)
   mockery::stub(qlm_code, "ellmer::parallel_chat_structured", mock_results)
 
-  # Capture warnings from cli::cli_warn
-  warnings_list <- list()
-  withCallingHandlers(
-    qlm_code(c("text1", "text2"), codebook, model = "test/model",
-             fake_argument = "value"),
-    warning = function(w) {
-      warnings_list <<- c(warnings_list, list(conditionMessage(w)))
-      invokeRestart("muffleWarning")
-    }
-  )
+  # Call with a provider-specific argument (like base_url for openai_compatible)
+  qlm_code(c("text1", "text2"), codebook, model = "test/model",
+           base_url = "https://my-api.com/v1")
 
-  # Verify warning was issued
-  expect_true(any(grepl("fake_argument", unlist(warnings_list))))
-  expect_true(any(grepl("not recognized", unlist(warnings_list))))
+  # Verify the provider-specific argument was passed through to ellmer::chat
+  expect_true("base_url" %in% names(chat_args_received))
+  expect_equal(chat_args_received$base_url, "https://my-api.com/v1")
 })
 
 

--- a/tests/testthat/test-qlm_segment.R
+++ b/tests/testthat/test-qlm_segment.R
@@ -245,7 +245,7 @@ test_that("qlm_segment warns for documents producing no segments", {
 })
 
 
-test_that("qlm_segment warns about unrecognized arguments", {
+test_that("qlm_segment passes provider-specific arguments to ellmer::chat", {
   skip_if_not_installed("ellmer")
   skip_if_not_installed("quanteda")
 
@@ -254,21 +254,21 @@ test_that("qlm_segment warns about unrecognized arguments", {
     schema = ellmer::type_object(tag = ellmer::type_string("Tag"))
   )
 
-  mock_chat <- structure(list(), class = "ellmer_chat")
+  # Track what arguments are passed to ellmer::chat
+  chat_args_received <- NULL
+  mock_chat <- function(...) {
+    chat_args_received <<- list(...)
+    structure(list(), class = "ellmer_chat")
+  }
   mock_results <- list(tibble::tibble(text = "A.", tag = "a"))
 
   mockery::stub(qlm_segment, "ellmer::chat", mock_chat)
   mockery::stub(qlm_segment, "ellmer::parallel_chat_structured", mock_results)
 
-  warnings_seen <- character(0)
-  withCallingHandlers(
-    qlm_segment("Text.", cb, model = "test/model", not_a_real_arg = TRUE),
-    warning = function(w) {
-      warnings_seen <<- c(warnings_seen, conditionMessage(w))
-      invokeRestart("muffleWarning")
-    }
-  )
+  # Call with a provider-specific argument (like base_url for openai_compatible)
+  qlm_segment("Text.", cb, model = "test/model", base_url = "https://my-api.com/v1")
 
-  expect_true(any(grepl("not_a_real_arg", warnings_seen)))
-  expect_true(any(grepl("not recognized", warnings_seen)))
+  # Verify the provider-specific argument was passed through to ellmer::chat
+  expect_true("base_url" %in% names(chat_args_received))
+  expect_equal(chat_args_received$base_url, "https://my-api.com/v1")
 })

--- a/vignettes/pkgdown/getting-started/workflow.Rmd
+++ b/vignettes/pkgdown/getting-started/workflow.Rmd
@@ -49,6 +49,8 @@ my_codebook <- qlm_codebook(
 my_codebook
 ```
 
+> **Tip:** Need to split texts into smaller units first? Use `qlm_segment()` to segment texts into thematic or conceptual units (e.g., quasi-sentences, aspects, or topics) before coding. For an example, see here: [Text segmentation](https://quallmer.github.io/quallmer/articles/pkgdown/examples/example_segmentation.html).
+
 ## Step 2: Code your data
 
 Apply the codebook to your texts using an LLM:


### PR DESCRIPTION
# Fix summary:

Addresses #99 

  Problem: qlm_code() and qlm_segment() filtered ... arguments to only pass those matching ellmer::chat() formal args. This blocked provider-specific arguments like base_url, credentials, and api_args needed for OpenAI-compatible endpoints.

  Solution:
  - Changed logic to pass everything not destined for execution functions (parallel_chat_structured/batch_chat_structured) to ellmer::chat()
  - Removed the "unrecognized arguments" warning
  - Let ellmer handle validation of provider-specific args

  Files changed:
  - R/qlm_code.R — fixed argument routing, updated docs
  - R/qlm_segment.R — same fix
  - tests/testthat/test-qlm_code.R — updated test to verify passthrough works
  - tests/testthat/test-qlm_segment.R — same

  Now works:
  qlm_code(
    texts, codebook,
    model = "openai_compatible/model-name",
    base_url = "https://my-server.com/v1",
    credentials = function() Sys.getenv("Token")
  )
