### PR TITLE
Make per-category reliability rows opt-in via by_category

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,15 +11,15 @@
 
 ## New features
 
-* `qlm_compare()` now reports per-category Krippendorff's alpha
-  (`alpha_per_value[k]`) for nominal data, alongside the existing
-  overall alpha. Each category is dichotomised against all others; the
-  marginal count `n` is reported in the `docid` column. Parallels the
-  per-value reporting already provided for unitizing alpha (#112).
-
-* `qlm_compare()` now reports per-category kappa (`kappa_per_value[k]`)
-  for nominal data: Cohen's κ via dichotomise-and-recompute for two
-  raters, Fleiss' formula (1971, Eqs. 20-21) for three or more (#112).
+* `qlm_compare()` gains a `by_category = FALSE` argument that, when
+  set to `TRUE`, reports per-category reliability rows for nominal
+  data: Krippendorff's alpha (`alpha_per_value[k]`, each category
+  dichotomised against all others), kappa (`kappa_per_value[k]`,
+  Cohen's κ via dichotomise-and-recompute for two raters or Fleiss'
+  Eqs. 20-21 for three or more), and `alpha_u_per_value[k]` for
+  unitizing comparisons. The marginal count `n` is reported in the
+  `docid` column. Per-category rows are only produced for
+  nominal-level data (#112).
 
 ## Internal changes
 

--- a/R/qlm_compare.R
+++ b/R/qlm_compare.R
@@ -34,6 +34,11 @@
 #'   }
 #' @param bootstrap_n Number of bootstrap resamples when `ci = "bootstrap"`.
 #'   Default is 1000. Ignored when `ci` is `"none"` or `"analytic"`.
+#' @param by_category Logical. If `TRUE`, include per-category reliability rows
+#'   (`alpha_per_value`, `kappa_per_value`, and `alpha_u_per_value` for unitizing
+#'   comparisons). Per-category rows are only produced for nominal-level data
+#'   (or nominal-coded segments in unitizing comparisons); they are not
+#'   meaningful for ordinal, interval, or ratio levels. Default is `FALSE`.
 #'
 #' @return A `qlm_comparison` object (a tibble/data frame) with the following columns:
 #'   \describe{
@@ -86,6 +91,13 @@
 #' simultaneously. For 3 or more raters, Spearman's rho and Pearson's r are
 #' computed as the mean of all pairwise correlations between raters.
 #'
+#' **Per-category statistics.** When `by_category = TRUE` and `level = "nominal"`,
+#' the result also includes one row per category for `alpha_per_value` (from
+#' Krippendorff's alpha) and `kappa_per_value` (per-category kappa via
+#' dichotomisation for Cohen's, Fleiss' eq. 20--21 for Fleiss'). The marginal
+#' count `n` for each category is carried in the `docid` column. Per-category
+#' rows are not produced for ordinal, interval, or ratio levels.
+#'
 #' **Unitizing (segmentation) reliability**
 #' `r lifecycle::badge("experimental")`
 #'
@@ -118,8 +130,9 @@
 #'     agree on the codes?" from "do they agree on the boundaries?"
 #'     (section 12.6.5, eqs. 36--37).}
 #'   \item{`alpha_u_per_value[k]` (`_(k)u`alpha\[nominal\])}{Computed
-#'     alongside `alpha_u_nominal` when `by` is specified. Reports the
-#'     reliability of each individual value `k`, showing which codes are
+#'     alongside `alpha_u_nominal` when `by` is specified **and**
+#'     `by_category = TRUE`. Reports the reliability of each individual
+#'     value `k`, showing which codes are
 #'     applied reliably and which are not. Coverage (the percentage of all
 #'     `k`-valued matter found in valued intersections) is reported in the
 #'     `docid` column (section 12.6.6, eq. 38).}
@@ -166,7 +179,12 @@ qlm_compare <- function(...,
                         level = NULL,
                         tolerance = 0,
                         ci = c("none", "analytic", "bootstrap"),
-                        bootstrap_n = 1000) {
+                        bootstrap_n = 1000,
+                        by_category = FALSE) {
+
+  if (!is.logical(by_category) || length(by_category) != 1L || is.na(by_category)) {
+    cli::cli_abort("{.arg by_category} must be a single {.code TRUE} or {.code FALSE}.")
+  }
 
   # Validate ci parameter
   ci <- match.arg(ci)
@@ -209,7 +227,8 @@ qlm_compare <- function(...,
   if (all(is_segment_corpus)) {
     lifecycle::signal_stage("experimental", "qlm_compare(unitizing)")
     return(compare_unitizations(coded_list, by = by, ci = ci,
-                                bootstrap_n = bootstrap_n))
+                                bootstrap_n = bootstrap_n,
+                                by_category = by_category))
   } else if (any(is_segment_corpus)) {
     cli::cli_abort(c(
       "Cannot mix segmented corpora with other object types in {.fn qlm_compare}.",
@@ -462,6 +481,7 @@ qlm_compare <- function(...,
       if (measure_name == "kappa_type") next
 
       if (measure_name %in% names(per_value_specs)) {
+        if (!by_category) next
         spec <- per_value_specs[[measure_name]]
         pv <- var_results[[measure_name]]
         if (is.null(pv) || nrow(pv) == 0L) next
@@ -999,7 +1019,8 @@ format_measure_name <- function(measure) {
 #' @keywords internal
 #' @noRd
 compare_unitizations <- function(corpus_list, by = NULL, ci = "none",
-                                  bootstrap_n = 1000) {
+                                  bootstrap_n = 1000,
+                                  by_category = FALSE) {
   m <- length(corpus_list)
 
   # Validate consistent source documents
@@ -1152,19 +1173,21 @@ compare_unitizations <- function(corpus_list, by = NULL, ci = "none",
         variable_name, measure_name, pick_value(res, is_boundaries), "(overall)"
       )
 
-      # For coded segments, also report cu_nominal and per_value
+      # For coded segments, also report cu_nominal and (optionally) per_value
       if (!is_boundaries) {
         all_results[[length(all_results) + 1L]] <- make_row(
           variable_name, "alpha_cu_nominal", res$cu_nominal, "(overall)"
         )
-        pv <- res$per_value
-        for (row_i in seq_len(nrow(pv))) {
-          all_results[[length(all_results) + 1L]] <- make_row(
-            variable_name,
-            paste0("alpha_u_per_value[", pv$value[row_i], "]"),
-            pv$alpha[row_i],
-            paste0("(overall, coverage=", sprintf("%.0f%%", 100 * pv$coverage[row_i]), ")")
-          )
+        if (by_category) {
+          pv <- res$per_value
+          for (row_i in seq_len(nrow(pv))) {
+            all_results[[length(all_results) + 1L]] <- make_row(
+              variable_name,
+              paste0("alpha_u_per_value[", pv$value[row_i], "]"),
+              pv$alpha[row_i],
+              paste0("(overall, coverage=", sprintf("%.0f%%", 100 * pv$coverage[row_i]), ")")
+            )
+          }
         }
       }
     }

--- a/man/qlm_compare.Rd
+++ b/man/qlm_compare.Rd
@@ -10,7 +10,8 @@ qlm_compare(
   level = NULL,
   tolerance = 0,
   ci = c("none", "analytic", "bootstrap"),
-  bootstrap_n = 1000
+  bootstrap_n = 1000,
+  by_category = FALSE
 )
 }
 \arguments{
@@ -48,6 +49,12 @@ Default is 0 (exact agreement required). Used for percent agreement calculation.
 
 \item{bootstrap_n}{Number of bootstrap resamples when \code{ci = "bootstrap"}.
 Default is 1000. Ignored when \code{ci} is \code{"none"} or \code{"analytic"}.}
+
+\item{by_category}{Logical. If \code{TRUE}, include per-category reliability rows
+(\code{alpha_per_value}, \code{kappa_per_value}, and \code{alpha_u_per_value} for unitizing
+comparisons). Per-category rows are only produced for nominal-level data
+(or nominal-coded segments in unitizing comparisons); they are not
+meaningful for ordinal, interval, or ratio levels. Default is \code{FALSE}.}
 }
 \value{
 A \code{qlm_comparison} object (a tibble/data frame) with the following columns:
@@ -111,6 +118,13 @@ Kendall's W, ICC, and percent agreement are computed using all raters
 simultaneously. For 3 or more raters, Spearman's rho and Pearson's r are
 computed as the mean of all pairwise correlations between raters.
 
+\strong{Per-category statistics.} When \code{by_category = TRUE} and \code{level = "nominal"},
+the result also includes one row per category for \code{alpha_per_value} (from
+Krippendorff's alpha) and \code{kappa_per_value} (per-category kappa via
+dichotomisation for Cohen's, Fleiss' eq. 20--21 for Fleiss'). The marginal
+count \code{n} for each category is carried in the \code{docid} column. Per-category
+rows are not produced for ordinal, interval, or ratio levels.
+
 \strong{Unitizing (segmentation) reliability}
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
@@ -143,8 +157,9 @@ intersections of non-gap segments only. This isolates "do the coders
 agree on the codes?" from "do they agree on the boundaries?"
 (section 12.6.5, eqs. 36--37).}
 \item{\code{alpha_u_per_value[k]} (\verb{_(k)u}alpha[nominal])}{Computed
-alongside \code{alpha_u_nominal} when \code{by} is specified. Reports the
-reliability of each individual value \code{k}, showing which codes are
+alongside \code{alpha_u_nominal} when \code{by} is specified \strong{and}
+\code{by_category = TRUE}. Reports the reliability of each individual
+value \code{k}, showing which codes are
 applied reliably and which are not. Coverage (the percentage of all
 \code{k}-valued matter found in valued intersections) is reported in the
 \code{docid} column (section 12.6.6, eq. 38).}

--- a/tests/testthat/test-alpha_u.R
+++ b/tests/testthat/test-alpha_u.R
@@ -261,6 +261,10 @@ test_that("qlm_compare nominal works with differing codes", {
   # Same boundaries but one code differs: alpha < 1.0 but > 0
   expect_true(overall < 1.0)
   expect_true(overall > 0)
-  # Per-value results should also be present
-  expect_true(any(grepl("alpha_u_per_value", result$measure)))
+  # Per-value rows are suppressed by default
+  expect_false(any(grepl("alpha_u_per_value", result$measure)))
+
+  # Opt-in via by_category = TRUE
+  result_cat <- qlm_compare(corp1, corp2, by = "code", by_category = TRUE)
+  expect_true(any(grepl("alpha_u_per_value", result_cat$measure)))
 })

--- a/tests/testthat/test-qlm_compare.R
+++ b/tests/testthat/test-qlm_compare.R
@@ -487,3 +487,67 @@ test_that("qlm_compare supports non-standard evaluation for by argument", {
   expect_equal(attr(comparison_nse, "n"), attr(comparison_quoted, "n"))
   expect_equal(attr(comparison_nse, "raters"), attr(comparison_quoted, "raters"))
 })
+
+
+test_that("qlm_compare suppresses per-category rows by default", {
+  coder1 <- data.frame(.id = 1:10, category = c(rep("A", 6), rep("B", 4)))
+  coder2 <- data.frame(.id = 1:10, category = c(rep("A", 5), rep("B", 5)))
+
+  default_result <- qlm_compare(coder1, coder2, by = category, level = "nominal")
+  expect_false(any(grepl("^alpha_per_value\\[", default_result$measure)))
+  expect_false(any(grepl("^kappa_per_value\\[", default_result$measure)))
+  # Overall measures still present
+  expect_true("alpha_nominal" %in% default_result$measure)
+  expect_true("kappa" %in% default_result$measure)
+})
+
+
+test_that("qlm_compare returns per-category rows when by_category = TRUE", {
+  coder1 <- data.frame(.id = 1:10, category = c(rep("A", 6), rep("B", 4)))
+  coder2 <- data.frame(.id = 1:10, category = c(rep("A", 5), rep("B", 5)))
+
+  result <- qlm_compare(coder1, coder2, by = category, level = "nominal",
+                       by_category = TRUE)
+  expect_true(any(grepl("^alpha_per_value\\[", result$measure)))
+  expect_true(any(grepl("^kappa_per_value\\[", result$measure)))
+  # docid carries marginal n for per-category rows
+  pv_rows <- result[grepl("^alpha_per_value\\[", result$measure), ]
+  expect_true(all(grepl("^\\(n=", pv_rows$docid)))
+})
+
+
+test_that("qlm_compare by_category has no effect on non-nominal levels", {
+  coder1 <- data.frame(.id = 1:10, score = c(1, 2, 3, 4, 5, 1, 2, 3, 4, 5))
+  coder2 <- data.frame(.id = 1:10, score = c(1, 2, 3, 4, 5, 2, 2, 3, 4, 5))
+
+  ordinal_default <- qlm_compare(coder1, coder2, by = score, level = "ordinal")
+  ordinal_by_cat  <- qlm_compare(coder1, coder2, by = score, level = "ordinal",
+                                 by_category = TRUE)
+  expect_identical(ordinal_default$measure, ordinal_by_cat$measure)
+  expect_false(any(grepl("per_value", ordinal_default$measure)))
+  expect_false(any(grepl("per_value", ordinal_by_cat$measure)))
+
+  interval_default <- qlm_compare(coder1, coder2, by = score, level = "interval")
+  interval_by_cat  <- qlm_compare(coder1, coder2, by = score, level = "interval",
+                                  by_category = TRUE)
+  expect_identical(interval_default$measure, interval_by_cat$measure)
+  expect_false(any(grepl("per_value", interval_default$measure)))
+  expect_false(any(grepl("per_value", interval_by_cat$measure)))
+})
+
+
+test_that("qlm_compare validates by_category argument", {
+  coder1 <- data.frame(.id = 1:5, category = c("A", "B", "A", "B", "A"))
+  coder2 <- data.frame(.id = 1:5, category = c("A", "B", "A", "B", "A"))
+
+  expect_error(
+    qlm_compare(coder1, coder2, by = category, level = "nominal",
+                by_category = "yes"),
+    "by_category"
+  )
+  expect_error(
+    qlm_compare(coder1, coder2, by = category, level = "nominal",
+                by_category = NA),
+    "by_category"
+  )
+})


### PR DESCRIPTION
`qlm_compare()` no longer emits `alpha_per_value`, `kappa_per_value`, or `alpha_u_per_value[k]` rows by default; users opt in with `by_category = TRUE`. Per-category rows remain restricted to nominal-level data (and nominal-coded segments in unitizing comparisons).

Fixes #115
